### PR TITLE
feat: add structured streaming using pyspark

### DIFF
--- a/spark_jobs/etl/ingest.py
+++ b/spark_jobs/etl/ingest.py
@@ -2,11 +2,9 @@ from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql.functions import split, col, concat_ws, to_timestamp, date_diff, current_date, broadcast, round
 from pyspark.sql.types import IntegerType
 
-from spark_jobs.utils.config import CASSANDRA_KEYSPACE
+from spark_jobs.utils.config import CASSANDRA_KEYSPACE, PROCESSED_DF_COLUMNS
 from spark_jobs.schemas import *
 from spark_jobs.utils import haversine_distance
-
-PROCESSED_DF_COLUMNS = ["cc_num", "trans_num", "trans_time", "category", "merchant", "amt", "merch_lat", "merch_long", "distance", "age", "is_fraud"]
 
 def load_customer_data(spark: SparkSession, customer_data_path: str) -> DataFrame:
     """

--- a/spark_jobs/ml_training/main.py
+++ b/spark_jobs/ml_training/main.py
@@ -12,13 +12,13 @@ def train_model_job():
     spark = get_spark_session("random_forest_model_training")
 
     # preprocessing pipeline
-    preprocessed_df, preprocessor_pipeline_model = preprocessing_pipeline(spark, CASSANDRA_KEYSPACE)
+    preprocessed_df, preprocessor = preprocessing_pipeline(spark, CASSANDRA_KEYSPACE)
 
     # balance dataframe since the ratio of fraudulent transactions is small compared to valid transactions
     train_df = balance_features_dataframe(preprocessed_df)
 
-    # train model
-    trained_model = train_model(train_df)
+    # train model - we pass preprocessor to create a single pipeline for transformation and prediction
+    trained_model = train_model(train_df, preprocessor)
 
     # persist to mlflow
     persist_artefacts(preprocessor_pipeline_model, trained_model)

--- a/spark_jobs/transactions_processor/main.py
+++ b/spark_jobs/transactions_processor/main.py
@@ -1,0 +1,27 @@
+import logging
+
+from spark_jobs.transactions_processor.process import get_artefact, read_and_cache_customer_data, \
+    read_data_from_kafka, preprocess_predict_persist
+
+from spark_jobs.utils.session import get_spark_session
+
+logger = logging.getLogger(__name__)
+
+def process_and_predict_job():
+    # load model artefacts
+    pipeline = get_artefact()
+
+    # create spark session
+    session = get_spark_session("transactions_processor")
+
+    # load customer data
+    customer_df = read_and_cache_customer_data(session)
+
+    # read data from kafka stream
+    parsed_df = read_data_from_kafka(session)
+
+    preprocess_predict_persist(customer_df, parsed_df, pipeline)
+
+if __name__ == "__main__":
+    logger.info("Starting transactions processor")
+    process_and_predict_job()

--- a/spark_jobs/transactions_processor/process.py
+++ b/spark_jobs/transactions_processor/process.py
@@ -1,0 +1,105 @@
+import mlflow
+from pyspark.ml import PipelineModel
+from pyspark.sql import SparkSession, DataFrame
+from pyspark.sql.functions import from_json, col, to_timestamp, broadcast, round
+from spark_jobs.schemas import transaction_schema
+from spark_jobs.utils import haversine_distance
+from spark_jobs.utils.config import (
+    CASSANDRA_KEYSPACE,
+    KAFKA_TOPIC,
+    PROCESSED_DF_COLUMNS,
+    MLFLOW_TRACKING_URI,
+    MLFLOW_EXPERIMENT_NAME
+)
+
+
+def get_pipeline_model() -> PipelineModel:
+    """
+    Retrieves the spark pipeline model from MLflow
+    """
+    mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+    mlflow.set_experiment(MLFLOW_EXPERIMENT_NAME)
+    pipeline = mlflow.spark.load_model("model")
+    return pipeline
+
+
+def read_and_cache_customer_data(spark: SparkSession) -> DataFrame:
+    """
+    Load customer data from Cassandra and cache for joins
+    """
+    customer_df = (
+        spark.read
+        .format("org.apache.spark.sql.cassandra")
+        .options(table_name="customers", keyspace=CASSANDRA_KEYSPACE)
+        .load()
+        .select("cc_num", "age", "lat", "long")
+    )
+    customer_df.cache()
+    return customer_df
+
+
+def read_kafka_stream(spark: SparkSession) -> DataFrame:
+    """
+    Read Kafka stream and parse to structured DataFrame
+    """
+    raw_df = (
+        spark.readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", "localhost:9092")
+        .option("subscribe", KAFKA_TOPIC)
+        .option("startingOffsets", "latest")
+        .load()
+    )
+
+    parsed_df = raw_df.selectExpr("CAST(value AS STRING) AS json", "partition", "offset")
+    return (
+        parsed_df
+        .select(from_json(col("json"), transaction_schema).alias("txn"), "partition", "offset")
+        .select("txn.*", "partition", "offset")
+        .withColumn("trans_time", to_timestamp(col("trans_time"), "yyyy-MM-dd HH:mm:ss"))
+    )
+
+
+def write_to_cassandra(batch_df: DataFrame, _: int):
+    """
+    Writes predictions to Cassandra
+    """
+    fraud_df = batch_df.filter(col("is_fraud") == 1.0)
+    non_fraud_df = batch_df.filter(col("is_fraud") != 1.0)
+
+    fraud_df.write.format("org.apache.spark.sql.cassandra") \
+        .mode("append") \
+        .options(table="fraud_transactions", keyspace=CASSANDRA_KEYSPACE).save()
+
+    non_fraud_df.write.format("org.apache.spark.sql.cassandra") \
+        .mode("append") \
+        .options(table="non_fraud_transactions", keyspace=CASSANDRA_KEYSPACE).save()
+
+
+def preprocess_predict_stream(customer_df: DataFrame, kafka_df: DataFrame, pipeline_model: PipelineModel):
+    """
+    Preprocess, predict and persist streaming data
+    """
+    processed_df = (
+        kafka_df
+        .join(broadcast(customer_df), on="cc_num", how="inner")
+        .withColumn(
+            "distance",
+            round(haversine_distance(col("lat"), col("long"), col("merch_lat"), col("merch_long")), 2)
+        )
+        .select(PROCESSED_DF_COLUMNS)
+    )
+
+    predictions_df = pipeline_model.transform(processed_df).withColumnRenamed("prediction", "is_fraud")
+
+    # Use foreachBatch for custom Cassandra writes
+    query = (
+        predictions_df.writeStream
+        .foreachBatch(write_to_cassandra)
+        .outputMode("append")
+        .option("checkpointLocation", "/tmp/spark_checkpoint_fraud")  # required for streaming
+        .start()
+    )
+
+    query.awaitTermination()
+

--- a/spark_jobs/utils/config.py
+++ b/spark_jobs/utils/config.py
@@ -4,10 +4,14 @@ CASSANDRA_PORT = 9042
 CUSTOMER_DATA_PATH = 'spark_jobs/data/customer.csv'
 TRANSACTION_DATA_PATH = 'spark_jobs/data/transactions.csv'
 
+PROCESSED_DF_COLUMNS = ["cc_num", "trans_num", "trans_time", "category", "merchant", "amt", "merch_lat", "merch_long", "distance", "age", "is_fraud"]
+
 CASSANDRA_KEYSPACE = 'creditcard'
 CASSANDRA_CUSTOMERS_TABLE = 'customers'
 CASSANDRA_FRAUD_TRANSACTIONS_TABLE = 'fraud_transactions'
 CASSANDRA_NON_FRAUD_TRANSACTIONS_TABLE = 'non_fraud_transactions'
+
+KAFKA_TOPIC = 'transactions'
 
 PREPROCESSOR_PATH = 'spark_jobs/ml_training/artefacts/preprocessing'
 RANDOM_FOREST_MODEL_PATH = 'spark_jobs/ml_training/artefacts/randomforest'


### PR DESCRIPTION
This PR adds the following changes

- update `config.py` with common columns and topic name
- update `ml_train` job to persisit a single pipeline model instead of two separate
- add `transactions processor` job